### PR TITLE
Changing the mltistate-union typo to multistate-union

### DIFF
--- a/R/taxPPro.R
+++ b/R/taxPPro.R
@@ -9,7 +9,7 @@
 #' @export
 #'
 filterData <- function(tbl) {
-    discrete_types <- c("binary", "multistate-intersection", "mltistate-union")
+    discrete_types <- c("binary", "multistate-intersection", "multistate-union")
     attr_type <- unique(tbl$Attribute_type)
     if (attr_type %in% discrete_types){
         output <- filterDataDiscrete(tbl)


### PR DESCRIPTION
- [x] Changing the typo error from `mltistate-union` to `multistate-union` in `filterData` function. 

With this typo, I think the corresponding scripts in the `taxPProValidation` might be affected. Let me know if this is true. 